### PR TITLE
Minor UI update and editable notes

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -7,24 +7,70 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <header>
-      <h1>Notes Dashboard</h1>
+    <header class="page-header">
+      <div>
+        <p class="badge">CR-002</p>
+        <h1>Notes Dashboard</h1>
+        <p class="text-muted">Add, edit, and organize your notes by topic.</p>
+      </div>
       <nav>
         <a href="login.html">Logout</a>
       </nav>
     </header>
-    <main>
-      <section id="notes-section">
-        <h2>Your Notes</h2>
-        <ul id="notes-list"></ul>
-        <form id="add-note-form">
-          <textarea
-            id="note-input"
-            placeholder="Write a new note..."
-            required
-          ></textarea>
-          <button type="submit">Add Note</button>
+    <main class="dashboard-shell">
+      <section class="card note-form-card">
+        <h2>Add a Note</h2>
+        <form id="note-form" class="note-form">
+          <div class="form-grid">
+            <label>
+              Title
+              <input
+                id="note-title"
+                name="title"
+                type="text"
+                placeholder="e.g., Sprint retro"
+                required
+              />
+            </label>
+            <label>
+              Topic
+              <input
+                id="note-topic"
+                name="topic"
+                type="text"
+                placeholder="e.g., Planning, Ideas, TODO"
+              />
+            </label>
+          </div>
+          <label>
+            Content
+            <textarea
+              id="note-content"
+              name="content"
+              placeholder="Capture your note details"
+              required
+            ></textarea>
+          </label>
+          <div class="actions">
+            <button type="submit" class="btn" id="save-note-btn">
+              Save note
+            </button>
+            <button type="button" class="btn ghost" id="cancel-edit-btn" hidden>
+              Cancel edit
+            </button>
+          </div>
         </form>
+      </section>
+
+      <section class="card note-list-card">
+        <div class="note-list-header">
+          <h2>Your Notes</h2>
+          <p class="text-muted" id="note-count"></p>
+        </div>
+        <div id="notes-empty" class="empty-state">
+          No notes yet. Add your first note above.
+        </div>
+        <ul id="notes-list" class="notes-grid"></ul>
       </section>
     </main>
     <script src="scripts/dashboard.js"></script>

--- a/src/login.html
+++ b/src/login.html
@@ -12,10 +12,7 @@
       <section class="auth-shell card">
         <header class="auth-header">
           <h1>Sign in to Notes Dashboard</h1>
-          <div class="auth-meta">
-            <span class="badge">CR-001</span>
-            <span>Baseline 2 development</span>
-          </div>
+          <p class="text-muted">Demo access for this prototype.</p>
         </header>
 
         <div

--- a/src/scripts/dashboard.js
+++ b/src/scripts/dashboard.js
@@ -1,33 +1,111 @@
 // scripts/dashboard.js
-// Simple notes dashboard logic using localStorage (can be replaced with JSON file backend)
-document.addEventListener('DOMContentLoaded', function() {
-    const notesList = document.getElementById('notes-list');
-    const addNoteForm = document.getElementById('add-note-form');
-    const noteInput = document.getElementById('note-input');
+// Notes dashboard with add/edit/delete using localStorage
+document.addEventListener("DOMContentLoaded", () => {
+    const form = document.getElementById("note-form");
+    const titleInput = document.getElementById("note-title");
+    const topicInput = document.getElementById("note-topic");
+    const contentInput = document.getElementById("note-content");
+    const notesList = document.getElementById("notes-list");
+    const noteCount = document.getElementById("note-count");
+    const emptyState = document.getElementById("notes-empty");
+    const cancelEditBtn = document.getElementById("cancel-edit-btn");
+    const saveBtn = document.getElementById("save-note-btn");
 
-    // Load notes from localStorage
-    function loadNotes() {
-        const notes = JSON.parse(localStorage.getItem('notes') || '[]');
-        notesList.innerHTML = '';
-        notes.forEach((note, idx) => {
-            const li = document.createElement('li');
-            li.textContent = note;
+    let editingId = null;
+
+    function getNotes() {
+        return JSON.parse(localStorage.getItem("notes") || "[]");
+    }
+
+    function setNotes(notes) {
+        localStorage.setItem("notes", JSON.stringify(notes));
+    }
+
+    function renderNotes() {
+        const notes = getNotes();
+        notesList.innerHTML = "";
+        noteCount.textContent = notes.length ? `${notes.length} note${notes.length > 1 ? "s" : ""}` : "";
+        emptyState.style.display = notes.length ? "none" : "block";
+
+        notes.forEach((note) => {
+            const li = document.createElement("li");
+            li.className = "note-card";
+            li.innerHTML = `
+                <div class="topic">${note.topic ? note.topic : "General"}</div>
+                <h3>${note.title || "Untitled"}</h3>
+                <p>${note.content || ""}</p>
+                <div class="meta">${new Date(note.createdAt).toLocaleString()}</div>
+                <div class="note-actions">
+                    <button data-id="${note.id}" class="edit">Edit</button>
+                    <button data-id="${note.id}" class="danger delete">Delete</button>
+                </div>
+            `;
             notesList.appendChild(li);
         });
     }
 
-    // Add new note
-    addNoteForm.addEventListener('submit', function(e) {
+    function resetForm() {
+        form.reset();
+        editingId = null;
+        cancelEditBtn.hidden = true;
+        saveBtn.textContent = "Save note";
+    }
+
+    form.addEventListener("submit", (e) => {
         e.preventDefault();
-        const note = noteInput.value.trim();
-        if (note) {
-            const notes = JSON.parse(localStorage.getItem('notes') || '[]');
-            notes.push(note);
-            localStorage.setItem('notes', JSON.stringify(notes));
-            noteInput.value = '';
-            loadNotes();
+        const title = titleInput.value.trim();
+        const topic = topicInput.value.trim();
+        const content = contentInput.value.trim();
+        if (!content) return;
+
+        const notes = getNotes();
+
+        if (editingId) {
+            const idx = notes.findIndex((n) => n.id === editingId);
+            if (idx !== -1) {
+                notes[idx] = { ...notes[idx], title, topic, content, updatedAt: Date.now() };
+            }
+        } else {
+            notes.unshift({
+                id: crypto.randomUUID ? crypto.randomUUID() : Date.now().toString(),
+                title,
+                topic,
+                content,
+                createdAt: Date.now(),
+            });
+        }
+
+        setNotes(notes);
+        renderNotes();
+        resetForm();
+    });
+
+    cancelEditBtn.addEventListener("click", () => {
+        resetForm();
+    });
+
+    notesList.addEventListener("click", (e) => {
+        const target = e.target;
+        if (target.matches("button.edit")) {
+            const id = target.getAttribute("data-id");
+            const note = getNotes().find((n) => n.id === id);
+            if (note) {
+                titleInput.value = note.title || "";
+                topicInput.value = note.topic || "";
+                contentInput.value = note.content || "";
+                editingId = id;
+                cancelEditBtn.hidden = false;
+                saveBtn.textContent = "Update note";
+            }
+        }
+
+        if (target.matches("button.delete")) {
+            const id = target.getAttribute("data-id");
+            const filtered = getNotes().filter((n) => n.id !== id);
+            setNotes(filtered);
+            renderNotes();
         }
     });
 
-    loadNotes();
+    renderNotes();
 });

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,46 +1,98 @@
 /* Dashboard Page Styles */
-#notes-section {
-  max-width: 600px;
-  margin: 2rem auto;
-  background: #fff;
-  padding: 2rem;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px;
+  max-width: 1100px;
+  margin: 0 auto;
 }
+
+header h1 {
+  margin: 0;
+  color: var(--text);
+}
+
+header nav a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+main {
+  max-width: 900px;
+  margin: 0 auto 48px;
+  padding: 0 20px;
+}
+
+#notes-section {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 28px;
+  color: var(--text);
+}
+
+#notes-section h2 {
+  margin-top: 0;
+  color: var(--text);
+}
+
 #notes-list {
   list-style: none;
   padding: 0;
-  margin-bottom: 1.5rem;
+  margin: 0 0 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
+
 #notes-list li {
-  background: #f0f0f0;
-  margin-bottom: 0.5rem;
-  padding: 0.75rem 1rem;
-  border-radius: 4px;
+  background: #0f1830;
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 12px 14px;
+  border-radius: 10px;
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.18);
 }
+
 #add-note-form {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 10px;
 }
+
 #note-input {
-  min-height: 60px;
-  padding: 0.5rem;
-  border-radius: 4px;
-  border: 1px solid #ccc;
+  min-height: 90px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: #0b1328;
+  color: var(--text);
 }
-button[type="submit"] {
+
+#note-input::placeholder {
+  color: var(--muted);
+}
+
+#add-note-form button[type="submit"] {
   align-self: flex-end;
-  padding: 0.5rem 1.5rem;
-  background: #007bff;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: background 0.2s;
+  background: linear-gradient(
+    90deg,
+    var(--accent) 0%,
+    var(--accent-strong) 100%
+  );
+  color: #0b1328;
+  padding: 12px 18px;
+  border-radius: 10px;
+  font-weight: 700;
+  box-shadow: 0 12px 28px rgba(34, 197, 94, 0.28);
 }
-button[type="submit"]:hover {
-  background: #0056b3;
+
+#add-note-form button[type="submit"]:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(34, 197, 94, 0.3);
 }
 :root {
   --bg: #0b1223;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,99 +1,3 @@
-/* Dashboard Page Styles */
-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 20px;
-  max-width: 1100px;
-  margin: 0 auto;
-}
-
-header h1 {
-  margin: 0;
-  color: var(--text);
-}
-
-header nav a {
-  color: var(--accent);
-  text-decoration: none;
-  font-weight: 600;
-}
-
-main {
-  max-width: 900px;
-  margin: 0 auto 48px;
-  padding: 0 20px;
-}
-
-#notes-section {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
-  padding: 28px;
-  color: var(--text);
-}
-
-#notes-section h2 {
-  margin-top: 0;
-  color: var(--text);
-}
-
-#notes-list {
-  list-style: none;
-  padding: 0;
-  margin: 0 0 18px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-#notes-list li {
-  background: #0f1830;
-  border: 1px solid var(--border);
-  color: var(--text);
-  padding: 12px 14px;
-  border-radius: 10px;
-  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.18);
-}
-
-#add-note-form {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-#note-input {
-  min-height: 90px;
-  padding: 12px 14px;
-  border-radius: 10px;
-  border: 1px solid var(--border);
-  background: #0b1328;
-  color: var(--text);
-}
-
-#note-input::placeholder {
-  color: var(--muted);
-}
-
-#add-note-form button[type="submit"] {
-  align-self: flex-end;
-  background: linear-gradient(
-    90deg,
-    var(--accent) 0%,
-    var(--accent-strong) 100%
-  );
-  color: #0b1328;
-  padding: 12px 18px;
-  border-radius: 10px;
-  font-weight: 700;
-  box-shadow: 0 12px 28px rgba(34, 197, 94, 0.28);
-}
-
-#add-note-form button[type="submit"]:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 16px 32px rgba(34, 197, 94, 0.3);
-}
 :root {
   --bg: #0b1223;
   --panel: #111a32;
@@ -114,11 +18,7 @@ main {
 body {
   margin: 0;
   font-family: "Segoe UI", Arial, sans-serif;
-  background: radial-gradient(
-      circle at 18% 20%,
-      rgba(34, 197, 94, 0.12),
-      transparent 32%
-    ),
+  background: radial-gradient(circle at 18% 20%, rgba(34, 197, 94, 0.12), transparent 32%),
     radial-gradient(circle at 82% 0%, rgba(59, 130, 246, 0.12), transparent 32%),
     var(--bg);
   color: var(--text);
@@ -136,7 +36,8 @@ button {
   font: inherit;
 }
 
-input {
+input,
+textarea {
   width: 100%;
   padding: 12px 14px;
   border-radius: 10px;
@@ -145,7 +46,8 @@ input {
   color: var(--text);
 }
 
-input:focus {
+input:focus,
+textarea:focus {
   outline: 2px solid rgba(34, 197, 94, 0.6);
 }
 
@@ -167,6 +69,13 @@ input:focus {
 .btn.is-disabled {
   opacity: 0.7;
   cursor: not-allowed;
+  box-shadow: none;
+}
+
+.btn.ghost {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border);
   box-shadow: none;
 }
 
@@ -244,4 +153,161 @@ input:focus {
   margin-top: 10px;
   color: var(--muted);
   font-size: 0.92rem;
+}
+
+/* Dashboard */
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 24px 20px 10px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.page-header h1 {
+  margin: 6px 0 4px;
+  color: var(--text);
+}
+
+.page-header nav a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.dashboard-shell {
+  max-width: 1100px;
+  margin: 0 auto 48px;
+  padding: 0 20px 40px;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 18px;
+}
+
+.note-form-card h2,
+.note-list-card h2 {
+  margin-top: 0;
+}
+
+.note-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.note-form textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.note-list-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.notes-grid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+}
+
+.note-card {
+  background: #0f1830;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px 14px 12px;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.22);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.note-card h3 {
+  margin: 0;
+  color: var(--text);
+  font-size: 1.05rem;
+}
+
+.note-card .topic {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.18);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  color: #b9d5ff;
+  font-size: 0.9rem;
+  width: fit-content;
+}
+
+.note-card p {
+  margin: 0;
+  color: var(--text);
+  opacity: 0.92;
+}
+
+.note-card .meta {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.note-card .note-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.note-card .note-actions button {
+  border-radius: 8px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+}
+
+.note-card .note-actions button:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.note-card .note-actions .danger {
+  border-color: rgba(239, 68, 68, 0.6);
+  color: #fca5a5;
+}
+
+.empty-state {
+  margin: 10px 0 0;
+  padding: 16px;
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  color: var(--muted);
+}
+
+@media (max-width: 640px) {
+  .page-header {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .note-card .note-actions {
+    justify-content: space-between;
+  }
 }


### PR DESCRIPTION
## Summary
Improves the login copy and upgrades the dashboard to a full note-taking experience with add/edit/delete and topic tagging.

## Changes
- Simplify login header text for the demo experience (src/login.html)
- Redesign dashboard layout with title/topic/content fields and improved hero/header (src/dashboard.html)
- Add editable notes logic: add, edit, delete, topic labels, counts, empty state, localStorage persistence (src/scripts/dashboard.js)
- Rebuild styles with consistent theme, card grid, buttons, and form spacing (src/styles.css)

## Testing
- Manual: login with demo/notes123 → access dashboard
- Add a note with title/topic/content → note appears with topic badge and timestamp
- Edit a note → fields populate and update on save
- Delete a note → card is removed; empty state shows when none remain
- Refresh → notes persist via localStorage